### PR TITLE
Potential fix for code scanning alert no. 27: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: { $eq: id } }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/MatheusFerrazz/juice-shop-dsa-ada/security/code-scanning/27](https://github.com/MatheusFerrazz/juice-shop-dsa-ada/security/code-scanning/27)

To fix the issue, we should avoid using the `$where` operator with dynamically constructed JavaScript expressions. Instead, we can rewrite the query to use a standard MongoDB query operator, such as `$eq`, which does not evaluate JavaScript code. This eliminates the risk of code injection entirely.

Specifically:
1. Replace the `$where` query with a safer query using the `$eq` operator to match the `orderId` field against the sanitized `id`.
2. Ensure that the `id` parameter is properly sanitized and validated before use.

The changes will be made in the `trackOrder` function in `routes/trackOrder.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
